### PR TITLE
Fix registration SSL cert error

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -79,12 +79,12 @@ class RegisterController extends Controller
                 'description' => '',
                 'politics' => '',
                 'interests' => '',
-                'role_id' => Role::where('title', 'User')->get('id'),
-                'municipality_id' => 1,
             ]);
+
             $votingLocation = VotingLocation::fromUser($user);
 
             $user->votingLocation()->associate($votingLocation);
+            $user->role()->associate(Role::where('title', 'User')->first());
             $user->save();
 
             return $user;

--- a/app/User.php
+++ b/app/User.php
@@ -25,7 +25,6 @@ class User extends Authenticatable
         'politics',
         'img_name',
         'interests',
-        'role_id',
     ];
 
     protected $dates = [

--- a/app/VotingLocation.php
+++ b/app/VotingLocation.php
@@ -35,7 +35,7 @@ class VotingLocation extends Model
 
     public static function fromUser($user)
     {
-        $client = new Client();
+        $client = new Client(['verify' => false ]);
         $response = $client->post('https://www.recenseamento.mai.gov.pt/consulta.ashx', [
             'form_params' => [
                 'nic' => $user->id_card,


### PR DESCRIPTION
User registration was broken for two reasons:
- role_id field was forcefully filled instead using associate
- SSL certificate check was failing because the government website is either using custom one or the client update through composer update broke it, a temporary fix was implemented by disabling the verification